### PR TITLE
Add device id to logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,13 +20,15 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version:'3.8.1'
 }
 
+def versionNumber = '4.0.0'
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
             groupId 'com.logentries'
             artifactId 'logentries-android'
-            version '3.0.3'
+            version versionNumber
         }
     }
 }
@@ -58,6 +60,10 @@ bintray {
         vcsUrl = gitUrl
         licenses = ['Apache-2.0']
         publicDownloadNumbers = true
+        version {
+            name = versionNumber
+            desc = 'Logentries for android'
+        }
     }
 }
 

--- a/src/main/java/com/logentries/misc/Utils.java
+++ b/src/main/java/com/logentries/misc/Utils.java
@@ -1,5 +1,8 @@
 package com.logentries.misc;
 
+import android.os.Build;
+import android.util.Log;
+
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -8,9 +11,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.UUID;
 import java.util.regex.Pattern;
-
-import android.os.Build;
-import android.util.Log;
 
 public class Utils {
 
@@ -104,6 +104,14 @@ public class Utils {
         return traceID;
     }
 
+
+    private static String getFormattedDeviceId(boolean toJSON) {
+        if(toJSON) {
+            return "\"DeviceId\": \"" + Build.SERIAL + "\"";
+        }
+        return "DeviceId=" + Build.SERIAL;
+    }
+
     public static String getFormattedTraceID(boolean toJSON) {
         if(toJSON) {
             return "\"TraceID\": \"" + traceID + "\"";
@@ -148,6 +156,10 @@ public class Utils {
         }
 
         sb.append(Utils.getFormattedTraceID(isUsingHttp)).append(" ");
+        sb.append(isUsingHttp ? ", " : " ");
+
+
+        sb.append(Utils.getFormattedDeviceId(isUsingHttp)).append(" ");
         sb.append(isUsingHttp ? ", " : " ");
 
         long timestamp = System.currentTimeMillis(); // Current time in UTC in milliseconds.


### PR DESCRIPTION
Add the device id (which is the device serial number) as part of the logging.
