### PR TITLE
Commented a log taking up LogCat space

### DIFF
--- a/lib/src/main/java/com/logentries/logger/LogStorage.java
+++ b/lib/src/main/java/com/logentries/logger/LogStorage.java
@@ -41,7 +41,7 @@ public class LogStorage {
             byte[] rawMessage = message.getBytes();
             long currSize = getCurrentStorageFileSize() + rawMessage.length;
             String sizeStr = Long.toString(currSize);
-            Log.d(TAG, "Current size: " + sizeStr);
+            //Log.d(TAG, "Current size: " + sizeStr);
             if (currSize >= MAX_QUEUE_FILE_SIZE) {
                 Log.d(TAG, "Log storage will be cleared because threshold of " + MAX_QUEUE_FILE_SIZE + " bytes has been reached");
                 reCreateStorageFile();


### PR DESCRIPTION
There was a line in lib/src/main/java/com/logentries/logger/LogStorage.java logging the current size of the cached logs while the mobile device was offline. This log took over the LogCat completely not allowing for any proper debugging. Very irritating. It was probably useful to someone else, but for us, it was just a burden. I've only changed it into a comment allowing others to still find it and uncomment it for their own debugging purposes. 
