### PR TITLE
Log message will be raw (no traceId or any other metadata which comming with logentries lib), if AndroidLogger.getInstance().setSendRawLogMessage(false) was set.

### DIFF
--- a/lib/src/main/java/com/logentries/logger/AsyncLoggingWorker.java
+++ b/lib/src/main/java/com/logentries/logger/AsyncLoggingWorker.java
@@ -342,8 +342,11 @@ public class AsyncLoggingWorker {
                             }
 
                             if (message != null) {
-                                this.leClient.write(Utils.formatMessage(message.replace("\n", LINE_SEP_REPLACER),
-                                        logHostName, useHttpPost));
+                                if(sendRawLogMessage){
+                                    this.leClient.write(Utils.formatMessage(message.replace("\n", LINE_SEP_REPLACER),logHostName, useHttpPost));
+                                }else{
+                                    this.leClient.write(message.replace("\n", LINE_SEP_REPLACER));
+                                }
                                 message = null;
                             }
 


### PR DESCRIPTION
Can you please accept this changes in order to send raw log messages. without any metadata